### PR TITLE
Add HIDE_POLYGON_ZOOM_LEVEL constant and update map overlays

### DIFF
--- a/src/utilities/Map/CustomMapEvents.js
+++ b/src/utilities/Map/CustomMapEvents.js
@@ -14,6 +14,7 @@ import {
   calculteSpeciesBasedPrice,
   formatNumber,
 } from './utililtyFunctions';
+import { HIDE_POLYGON_ZOOM_LEVEL } from 'variables/forest';
 
 CustomMapEvents.propTypes = {
   activeOverlay: PropTypes.shape({
@@ -142,7 +143,7 @@ export default function CustomMapEvents({
     zoom: async (e) => {
       let flag = false;
       setZoomLevel(map.getZoom());
-      if (map.getZoom() > 13) {
+      if (map.getZoom() > HIDE_POLYGON_ZOOM_LEVEL) {
         flag = true;
       }
       setActiveOverlay((prevOverlay) => ({
@@ -249,7 +250,7 @@ export default function CustomMapEvents({
           hideLayerControlLabel('HogstklasserWMS');
           hideLayerControlLabel('Polygons');
         }, 0);
-        !(zoomLevel <= 13) &&
+        !(zoomLevel <= HIDE_POLYGON_ZOOM_LEVEL) &&
           setActiveOverlay((prevOverlay) => ({
             ...prevOverlay,
             Hogstklasser: false,
@@ -257,7 +258,7 @@ export default function CustomMapEvents({
             Polygons: false,
           }));
       }
-      !(zoomLevel <= 13) &&
+      !(zoomLevel <= HIDE_POLYGON_ZOOM_LEVEL) &&
         setActiveOverlay((prevOverlay) => ({
           ...prevOverlay,
           [e.name]: false,

--- a/src/variables/forest.js
+++ b/src/variables/forest.js
@@ -43,3 +43,6 @@ export const SPECIES_PRICES = {
   FURU: 537,
   LAU: 486,
 };
+
+export const HIDE_POLYGON_ZOOM_LEVEL = 10;
+export const MAP_DEFAULT_ZOOM_LEVEL = 13;

--- a/src/views/Map.js
+++ b/src/views/Map.js
@@ -19,7 +19,11 @@ import {
 import CustomMapEvents from 'utilities/Map/CustomMapEvents';
 import FeaturePopup from 'utilities/Map/FeaturePopup';
 import { hideLayerControlLabel } from 'utilities/Map/utililtyFunctions';
-import { mapCoordinations } from 'variables/forest';
+import {
+  HIDE_POLYGON_ZOOM_LEVEL,
+  MAP_DEFAULT_ZOOM_LEVEL,
+  mapCoordinations,
+} from 'variables/forest';
 
 const { BaseLayer, Overlay } = LayersControl;
 delete L.Icon.Default.prototype._getIconUrl;
@@ -43,7 +47,7 @@ function Map() {
   });
 
   const [activeFeature, setActiveFeature] = useState(null);
-  const [zoomLevel, setZoomLevel] = useState(13);
+  const [zoomLevel, setZoomLevel] = useState(MAP_DEFAULT_ZOOM_LEVEL);
   const imageBounds = [
     [59.9283312840000022, 11.6844372829999994], // Bottom-left corner
     [59.9593366419999967, 11.7499393919999999], // Top-right corner
@@ -123,7 +127,10 @@ function Map() {
           </BaseLayer>
           {PNGImage && (
             <Overlay
-              checked={zoomLevel > 13 && activeOverlay['Hogstklasser']}
+              checked={
+                zoomLevel > HIDE_POLYGON_ZOOM_LEVEL &&
+                activeOverlay['Hogstklasser']
+              }
               name="Hogstklasser"
             >
               <ImageOverlay url={PNGImage} bounds={imageBounds} opacity={1} />
@@ -143,7 +150,10 @@ function Map() {
             </Overlay>
           )}
           <Overlay
-            checked={zoomLevel > 13 && activeOverlay['Hogstklasser']}
+            checked={
+              zoomLevel > HIDE_POLYGON_ZOOM_LEVEL &&
+              activeOverlay['Hogstklasser']
+            }
             name="HogstklasserWMS"
           >
             <WMSTileLayer
@@ -158,7 +168,10 @@ function Map() {
           {madsForestSievePolySimplified && (
             <Overlay
               name="Polygons"
-              checked={zoomLevel > 13 && activeOverlay['Hogstklasser']}
+              checked={
+                zoomLevel > HIDE_POLYGON_ZOOM_LEVEL &&
+                activeOverlay['Hogstklasser']
+              }
             >
               <GeoJSON
                 data={madsForestSievePolySimplified}
@@ -170,7 +183,9 @@ function Map() {
           {madsForestAR50CRS4326 && (
             <Overlay
               name="AR50"
-              checked={zoomLevel > 13 && activeOverlay['AR50']}
+              checked={
+                zoomLevel > HIDE_POLYGON_ZOOM_LEVEL && activeOverlay['AR50']
+              }
             >
               <GeoJSON
                 data={madsForestAR50CRS4326}
@@ -192,7 +207,9 @@ function Map() {
           {madsForestCLCClipCRS4326 && (
             <Overlay
               name="CLC"
-              checked={zoomLevel > 13 && activeOverlay['CLC']}
+              checked={
+                zoomLevel > HIDE_POLYGON_ZOOM_LEVEL && activeOverlay['CLC']
+              }
             >
               <GeoJSON
                 data={madsForestCLCClipCRS4326}
@@ -213,7 +230,9 @@ function Map() {
           )}
           <Overlay
             name="Matrikkel"
-            checked={zoomLevel > 13 && activeOverlay['Matrikkel']}
+            checked={
+              zoomLevel > HIDE_POLYGON_ZOOM_LEVEL && activeOverlay['Matrikkel']
+            }
           >
             <WMSTileLayer
               url="https://openwms.statkart.no/skwms1/wms.matrikkelkart"


### PR DESCRIPTION
This pull request adds a new constant, HIDE_POLYGON_ZOOM_LEVEL, to the codebase. It also updates the map overlays to use this constant instead of the hard-coded value of 13. This change ensures that the polygons are hidden at the specified zoom level.