### PR TITLE
Add clickedOnLine state and setClickedOnLine prop

### DIFF
--- a/src/views/Map.js
+++ b/src/views/Map.js
@@ -71,19 +71,21 @@ function Map() {
 
     geoJSONLayer.on({
       click: () => {
-        setActiveFeature(feature);
-        // Highlight the selected polygon
-        if (activeGeoJSONLayer) {
-          activeGeoJSONLayer.setStyle({
-            fillColor: 'transparent',
-            fillOpacity: 0,
-          }); // Reset style of previous active layer
+        if (feature.properties.DN !== 99) {
+          setActiveFeature(feature);
+          // Highlight the selected polygon
+          if (activeGeoJSONLayer) {
+            activeGeoJSONLayer.setStyle({
+              fillColor: 'transparent',
+              fillOpacity: 0,
+            }); // Reset style of previous active layer
+          }
+          geoJSONLayer.setStyle({
+            fillColor: 'rgb(255, 255, 0)',
+            fillOpacity: 1,
+          }); // Set style of current active layer to neon yellow
+          activeGeoJSONLayer = geoJSONLayer; // Update active layer
         }
-        geoJSONLayer.setStyle({
-          fillColor: 'rgb(255, 255, 0)',
-          fillOpacity: 1,
-        }); // Set style of current active layer to neon yellow
-        activeGeoJSONLayer = geoJSONLayer; // Update active layer
       },
     });
   };

--- a/src/views/Map.js
+++ b/src/views/Map.js
@@ -46,6 +46,7 @@ function Map() {
     CLS: false,
   });
 
+  const [clickedOnLine, setClickedOnLine] = useState(false);
   const [activeFeature, setActiveFeature] = useState(null);
   const [zoomLevel, setZoomLevel] = useState(MAP_DEFAULT_ZOOM_LEVEL);
   const imageBounds = [
@@ -71,21 +72,23 @@ function Map() {
 
     geoJSONLayer.on({
       click: () => {
+        setActiveFeature(feature);
+        // Highlight the selected polygon
+        if (activeGeoJSONLayer) {
+          activeGeoJSONLayer.setStyle({
+            fillColor: 'transparent',
+            fillOpacity: 0,
+          }); // Reset style of previous active layer
+        }
         if (feature.properties.DN !== 99) {
-          setActiveFeature(feature);
-          // Highlight the selected polygon
-          if (activeGeoJSONLayer) {
-            activeGeoJSONLayer.setStyle({
-              fillColor: 'transparent',
-              fillOpacity: 0,
-            }); // Reset style of previous active layer
-          }
           geoJSONLayer.setStyle({
             fillColor: 'rgb(255, 255, 0)',
             fillOpacity: 1,
           }); // Set style of current active layer to neon yellow
-          activeGeoJSONLayer = geoJSONLayer; // Update active layer
+        } else {
+          return {}; // Default style for other features
         }
+        activeGeoJSONLayer = geoJSONLayer; // Update active layer
       },
     });
   };
@@ -112,6 +115,8 @@ function Map() {
           desiredGeoJSON={madsTeig}
           setZoomLevel={setZoomLevel}
           zoomLevel={zoomLevel}
+          clickedOnLine={clickedOnLine}
+          setClickedOnLine={setClickedOnLine}
         />
         <ZoomControl position="bottomright" />
         <LayersControl position="bottomright">


### PR DESCRIPTION
This commit adds a new state variable called clickedOnLine and a corresponding prop setClickedOnLine to the CustomMapEvents component. This state variable is used to track whether a line feature was clicked on the map. The setClickedOnLine prop is used to update the value of clickedOnLine. This change allows for conditional logic in the click event handler to prevent executing certain code when a line feature is clicked.