### PR TITLE
Fix CSV lookup for estimated height and adjust map zoom level

### DIFF
--- a/src/utilities/Map/utililtyFunctions.js
+++ b/src/utilities/Map/utililtyFunctions.js
@@ -46,7 +46,9 @@ export const calculateEstimatedHeightAndCrossSectionArea = (
 
   if (CSVRow) {
     const featureAgeString = featureValues.alder;
-    estimatedHeightFromCSVString = CSVRow[featureAgeString];
+    estimatedHeightFromCSVString =
+      CSVRow[featureAgeString] ||
+      CSVRow[Math.ceil(Number.parseInt(featureAgeString) / 5) * 5];
     const featureAgeNumber = parseInt(featureValues.alder);
     const bonitetHT40Number = parseFloat(CSVRow.Ht40.replace(',', '.'));
 

--- a/src/views/Map.js
+++ b/src/views/Map.js
@@ -118,7 +118,7 @@ function Map() {
   // eslint-disable-next-line react/prop-types
   const ChangeView = ({ center, zoom }) => {
     const map = useMap();
-    selectedForestFirstTime && map.setView(center, zoom);
+    selectedForestFirstTime && map.setView(center, 13);
     // To solve the issue with the always centering the map after choosing a forest
     setSelectedForestFirstTime(false);
     return null;


### PR DESCRIPTION
This pull request fixes the CSV lookup for estimated height and adjusts the map zoom level. The estimated height lookup now falls back to the nearest multiple of 5 if the exact value is not found in the CSV. Additionally, the map zoom level is set to 13 when selecting a forest for the first time to prevent the map from always centering.