### PR TITLE
Update WMS URL and image format

### DIFF
--- a/src/views/Map.js
+++ b/src/views/Map.js
@@ -313,9 +313,10 @@ function Map() {
           </Overlay>
           <Overlay name="High Resolution" checked>
             <WMSTileLayer
-              url="http://localhost:5001/wms"
+              url="https://services.geodataonline.no:443/arcgis/services/Geocache_UTM33_EUREF89/GeocacheBilder/MapServer/WMSServer"
+              // url="https://xvkdluncc4.execute-api.eu-north-1.amazonaws.com/Prod/hello"
               layers="0"
-              format="image/png"
+              format="image/jpeg"
               version="1.3.0"
             />
           </Overlay>


### PR DESCRIPTION
This pull request updates the WMS URL and image format in the Map.js file. The previous URL was "http://localhost:5001/wms" and the new URL is "https://services.geodataonline.no:443/arcgis/services/Geocache_UTM33_EUREF89/GeocacheBilder/MapServer/WMSServer". Additionally, the image format has been changed from "image/png" to "image/jpeg".