### PR TITLE
"Refactor overlay property names to use 'Skogbruksplan' instead of 'WMSHogstklasser'"

### DIFF
--- a/src/utilities/Map/CustomMapEvents.js
+++ b/src/utilities/Map/CustomMapEvents.js
@@ -15,7 +15,7 @@ CustomMapEvents.propTypes = {
   activeOverlay: PropTypes.shape({
     Teig: PropTypes.bool,
     Stands: PropTypes.bool,
-    WMSHogstklasser: PropTypes.bool,
+    Skogbruksplan: PropTypes.bool,
   }).isRequired,
   setActiveOverlay: PropTypes.func.isRequired,
   setDeselectPolygons: PropTypes.func.isRequired,
@@ -452,7 +452,7 @@ export default function CustomMapEvents(props) {
       }
       if (
         !clickedOnLineRef.current &&
-        (activeOverlay['Stands'] || activeOverlay['WMSHogstklasser'])
+        (activeOverlay['Stands'] || activeOverlay['Skogbruksplan'])
       ) {
         // By default we are closing all the popups, in case there are any opens
         //  an then we will show the pop up after the new call to the WMS and once
@@ -560,7 +560,7 @@ export default function CustomMapEvents(props) {
       }));
     },
     overlayremove: async (e) => {
-      if (activeOverlay['Stands'] || activeOverlay['WMSHogstklasser']) {
+      if (activeOverlay['Stands'] || activeOverlay['Skogbruksplan']) {
         map.closePopup();
       }
     },

--- a/src/utilities/Map/CustomMapEvents.js
+++ b/src/utilities/Map/CustomMapEvents.js
@@ -8,12 +8,13 @@ import {
   calculateVolumeAndGrossValue,
   convertAndformatTheStringArealM2ToDAA,
   formatNumber,
-  isPointInsidePolygon,
+  isPointInsideTeig,
 } from './utililtyFunctions';
 
 CustomMapEvents.propTypes = {
   activeOverlay: PropTypes.shape({
     Teig: PropTypes.bool,
+    MIS: PropTypes.bool,
     Stands: PropTypes.bool,
     Skogbruksplan: PropTypes.bool,
   }).isRequired,
@@ -482,7 +483,7 @@ export default function CustomMapEvents(props) {
 
         if (
           clickedForest &&
-          isPointInsidePolygon(
+          isPointInsideTeig(
             e.latlng,
             clickedForest.features[0].geometry.coordinates
           ) &&

--- a/src/utilities/Map/utililtyFunctions.js
+++ b/src/utilities/Map/utililtyFunctions.js
@@ -104,7 +104,7 @@ export const calculatestandVolumeWMSDensityPerHectareWMS = (
   return (parseInt(arealm2) / 10000) * standVolumeWMS;
 };
 
-export const isPointInsidePolygon = (point, polygon) => {
+export const isPointInsideTeig = (point, polygon) => {
   const turfPoint = turf.point([point.lng, point.lat]);
   const turfPolygon = turf.multiPolygon(polygon);
   return turf.booleanPointInPolygon(turfPoint, turfPolygon);

--- a/src/views/Map.js
+++ b/src/views/Map.js
@@ -52,6 +52,7 @@ L.Icon.Default.mergeOptions({
 function Map() {
   const [activeOverlay, setActiveOverlay] = useState({
     Teig: true,
+    MIS: true,
     Stands: true,
     Skogbruksplan: false,
   });
@@ -229,7 +230,6 @@ function Map() {
     // Clear the array after resetting styles
     setDeselectPolygons(true);
   };
-
   return (
     <>
       <ForestSelector
@@ -445,6 +445,17 @@ function Map() {
               format="image/jpeg"
               version="1.3.0"
               maxZoom={22}
+            />
+          </Overlay>
+          {/* MIS */}
+          <Overlay name="MIS" checked={activeOverlay['MIS']}>
+            <WMSTileLayer
+              url="https://wms.nibio.no/cgi-bin/mis"
+              layers="Livsmiljo_ikkeutvalgt,Livsmiljo,Hule_lauvtrar_punkt,Rikbarkstrar_alle,Trar_m_hengelav_alle,Bekkeklofter,Leirraviner,Rik_bakkevegetasjon,Brannflater,Gamle_trar,Eldre_lauvsuksesjon,Liggende_dod_ved,Staende_dod_ved,Nokkelbiotop,Bergvegger_alle"
+              language="nor"
+              format="image/png"
+              transparent={true}
+              version="1.3.0"
             />
           </Overlay>
         </LayersControl>

--- a/src/views/Map.js
+++ b/src/views/Map.js
@@ -53,7 +53,7 @@ function Map() {
   const [activeOverlay, setActiveOverlay] = useState({
     Teig: true,
     Stands: true,
-    WMSHogstklasser: false,
+    Skogbruksplan: false,
   });
 
   const forest1 = mapCoordinations.madsForestPosition;
@@ -239,7 +239,7 @@ function Map() {
       />
       <ToggleSwitch
         id="multiPolygon"
-        disabled={!activeOverlay['Stands'] && !activeOverlay['WMSHogstklasser']}
+        disabled={!activeOverlay['Stands'] && !activeOverlay['Skogbruksplan']}
         style={{
           position: 'absolute',
           top: 80,
@@ -318,10 +318,10 @@ function Map() {
               attribution='&copy; <a href="https://www.esri.com/">Esri</a> contributors'
             />
           </BaseLayer>
-          {/* WMSHogstklasser */}
+          {/* Skogbruksplan */}
           <Overlay
-            checked={activeOverlay['WMSHogstklasser']}
-            name="WMSHogstklasser"
+            checked={activeOverlay['Skogbruksplan']}
+            name="Skogbruksplan"
           >
             <LayerGroup>
               {selectedForest.name === 'forest1' && (


### PR DESCRIPTION
The code changes in CustomMapEvents.js and Map.js update the usage of the 'WMSHogstklasser' property to 'Skogbruksplan' for determining the active overlay. This change aligns with recent user and repository commits, improving code clarity and consistency. Additionally, the pull request includes other refactoring changes and a new feature to add the MIS layer without GetFeatureInfo functionality.