### PR TITLE
Fix FS size exceed by downloading directly from S3

### DIFF
--- a/src/views/Map.js
+++ b/src/views/Map.js
@@ -15,7 +15,6 @@ import {
 } from 'react-leaflet';
 import { Button } from 'reactstrap';
 import CustomMapEvents from 'utilities/Map/CustomMapEvents';
-import { decompressBase64ToGeoJSON } from 'utilities/Map/utililtyFunctions.js';
 import { MAP_DEFAULT_ZOOM_LEVEL } from 'variables/forest.js';
 import '../utilities/Map/PopupMovable.js';
 import '../utilities/Map/SmoothWheelZoom.js';
@@ -418,9 +417,7 @@ function Map() {
                   <GeoJSON
                     ref={userPolygonsRef}
                     onEachFeature={onEachFeature}
-                    data={decompressBase64ToGeoJSON(
-                      persistedUser.FBUser.forest.vector
-                    )}
+                    data={persistedUser.FBUser.forest.vector}
                   />
                 </LayerGroup>
               </Overlay>


### PR DESCRIPTION
This pull request fixes an issue where the file size of the ForestFeatureInfo component exceeded the allowed limit by downloading directly from S3. The changes include removing the pako library import, updating the interval for checking file existence, and removing the compression and base64 conversion of GeoJSON data. Additionally, the AuthProvider component now downloads the PNG image and SHP files from S3 and converts the SHP files to GeoJSON. The Map component has been updated to use the GeoJSON data directly without decompressing it.